### PR TITLE
added variable for other_documents that can be set in answer

### DIFF
--- a/docassemble/VTSmallClaimsCertificateOfService/data/questions/small_claims_certificate_of_service.yml
+++ b/docassemble/VTSmallClaimsCertificateOfService/data/questions/small_claims_certificate_of_service.yml
@@ -53,8 +53,8 @@ attachments:
           % else:
           $ { False }
           % endif
-      - "other_document":
-      - "other_document_describe":
+      - "other_document": ${ other_document }
+      - "other_document_describe": ${ other_document_describe }
       - "COS_signer_name": ${ attorneys[0] if user_has_attorney else users[0] }
       - "COS_mailing_address_line_one": |
           % if defined("users[0].mailing_address.address"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Legal Services Vermont", email = "ksurette@legalservicesvt.org" },
 ]
 dependencies = [
-    "docassemble.AssemblyLine @ git+https://github.com/SuffolkLITLab/docassemble-AssemblyLine.git@main",
+    "docassemble.AssemblyLine @ git+https://github.com/suffolklitlab/docassemble-AssemblyLine.git@main",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.VTSmallClaimsCertificateOfService',
       license='',
       url='https://docassemble.org',
       packages=find_namespace_packages(),
-      install_requires=['docassemble.AssemblyLine @ git+https://github.com/SuffolkLITLab/docassemble-AssemblyLine.git@main'],
+      install_requires=['docassemble.AssemblyLine @ git+https://github.com/suffolklitlab/docassemble-AssemblyLine.git@main'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/VTSmallClaimsCertificateOfService/', package='docassemble.VTSmallClaimsCertificateOfService'),
      )


### PR DESCRIPTION
fix #3 by adding a variable that can be set in other interviews

shouldn't affect other interviews because skip undefined: True is on (unless other interviews use the variable other_documents)